### PR TITLE
Build for OBS 29.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,16 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   windows:
     name: "Windows 64bit"
     runs-on: windows-latest
     env:
-      OBS_DEPS: "2022-08-02"
+      OBS_DEPS: "2023-04-12"
       CMAKE_GENERATOR: "Visual Studio 17 2022"
       CMAKE_SYSTEM_VERSION: "10.0"
       # TODO: Don't ACTIONS_ALLOW_UNSECURE_COMMANDS

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Windows 64bit"
     runs-on: windows-latest
     env:
-      OBS_DEPS: "2022-08-02"
+      OBS_DEPS: "2023-04-12"
       CMAKE_GENERATOR: "Visual Studio 17 2022"
       CMAKE_SYSTEM_VERSION: "10.0"
       # TODO: Don't ACTIONS_ALLOW_UNSECURE_COMMANDS

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ src/virtual-output/virtualoutput.rc
 src/virtual-source/virtualsource.rc
 build64/
 obs-deps/
+.vs/
+out/build/

--- a/make.ps1
+++ b/make.ps1
@@ -1,7 +1,7 @@
 $parent = (Get-Item $PSScriptRoot ).parent.FullName
 cmake -S . -B build64 `
-  -DQTDIR="$PSScriptRoot/obs-deps/windows-deps-qt6-2022-08-02-x64" `
-  -DDepsPath="$PSScriptRoot/obs-deps/windows-deps-2022-08-02-x64" `
+  -DQTDIR="$PSScriptRoot/obs-deps/windows-deps-qt6-2023-04-12-x64" `
+  -DDepsPath="$PSScriptRoot/obs-deps/windows-deps-2023-04-12-x64" `
   -DLIBOBS_INCLUDE_DIR="$parent/obs-studio/libobs" `
   -DLIBOBS_LIB="$parent/obs-studio/build64/libobs/RelWithDebInfo/obs.lib" `
   -DOBS_FRONTEND_LIB="$parent/obs-studio/build64/UI/obs-frontend-api/RelWithDebInfo/obs-frontend-api.lib" `

--- a/readme.MD
+++ b/readme.MD
@@ -1,6 +1,6 @@
 # ⚠ Unofficial support
 
-You should really be using the integrated OBS Virtual Camera over this plugin. This is used as a stop-gap for things that don't yet work with the integrated Virtual Camera (like https://github.com/obsproject/obs-studio/issues/3635 and https://github.com/opencv/opencv/issues/19746). I do not plan on supporting this fork outside of necessary updates if OBS breaks the plugin. And will only do so until the aforementionned issue is fixed.
+You should really be using the integrated OBS Virtual Camera over this plugin. This is used as a stop-gap for things that don't yet work with the integrated Virtual Camera (like <https://github.com/obsproject/obs-studio/issues/3635> and <https://github.com/opencv/opencv/issues/19746>). I do not plan on supporting this fork outside of necessary updates if OBS breaks the plugin. And will only do so until the aforementionned issue is fixed.
 
 # OBS-VirtualCam
 
@@ -46,12 +46,12 @@ regsvr32 /n /i:"2" "C:\Program Files\obs-studio\bin\64bit\obs-virtualsource.dll"
 
 # Build
 
-You first need to install [cmake](https://cmake.org/download/), [Visual Studio](https://visualstudio.microsoft.com/), and [build OBS project](https://github.com/obsproject/obs-studio/wiki/Install-Instructions#building-obs-studio).
-Run cmake with the following variables:
+You first need to install [cmake](https://cmake.org/download/), [Visual Studio](https://visualstudio.microsoft.com/), and [build OBS project](https://github.com/obsproject/obs-studio/wiki/Install-Instructions#building-obs-studio).  
+You must also download `windows-deps-2023-04-12-x64` and `windows-deps-qt6-2023-04-12-x64` from [OBS Deps](https://github.com/obsproject/obs-deps/releases/tag/2023-04-12), then extract the zip as a folder of the same name and place them in `<project_root>/obs-deps/`
 
 * **QTDIR** (path): QT folder
 * **DepsPath** (path): FFmpeg folder in OBS dependencies package
-* **LIBOBS_INCLUDE_DIR** (path) : Libobs  include folder
+* **LIBOBS_INCLUDE_DIR** (path) : Libobs include folder
 * **LIBOBS_LIB** (filepath) : obs.lib path
 * **OBS_FRONTEND_LIB** (filepath): obs-frontend-api.lib path
 * **PTHREAD_LIB** (filepath): w32-pthread.lib path
@@ -60,8 +60,8 @@ ie:
 
 ```powershell
 cmake -S . -B build64 `
-  -DQTDIR=<...>/obs-deps/windows-deps-qt6-2022-08-02-x64 `
-  -DDepsPath=<...>/obs-deps/windows-deps-2022-08-02-x64 `
+  -DQTDIR=<...>/obs-deps/windows-deps-qt6-2023-04-12-x64 `
+  -DDepsPath=<...>/obs-deps/windows-deps-2023-04-12-x64 `
   -DLIBOBS_INCLUDE_DIR=<...>/obs-studio/libobs `
   -DLIBOBS_LIB=<...>/obs-studio/build64/libobs/RelWithDebInfo/obs.lib `
   -DOBS_FRONTEND_LIB=<...>/obs-studio/build64/UI/obs-frontend-api/RelWithDebInfo/obs-frontend-api.lib `

--- a/src/virtual-output/hflip.cpp
+++ b/src/virtual-output/hflip.cpp
@@ -12,8 +12,6 @@ bool init_flip_filter(FlipContext* ctx,int width, int height, int format)
 	const AVFilter *buffersink = avfilter_get_by_name("buffersink");
 	AVFilterInOut *outputs = avfilter_inout_alloc();
 	AVFilterInOut *inputs = avfilter_inout_alloc();
-	enum AVPixelFormat pix_fmts[] = { (AVPixelFormat)format, AV_PIX_FMT_NONE };
-	AVBufferSinkParams *buffersink_params;
 
 	ctx->filter_graph = avfilter_graph_alloc();
 	sprintf(args,
@@ -27,11 +25,8 @@ bool init_flip_filter(FlipContext* ctx,int width, int height, int format)
 		return false;
 	}
 
-	buffersink_params = av_buffersink_params_alloc();
-	buffersink_params->pixel_fmts = pix_fmts;
 	ret = avfilter_graph_create_filter(&ctx->buffersink_ctx, buffersink, "out",
-		NULL, buffersink_params, ctx->filter_graph);
-	av_free(buffersink_params);
+		NULL, NULL, ctx->filter_graph);
 
 	if (ret < 0) {
 		avfilter_graph_free(&ctx->filter_graph);


### PR DESCRIPTION
- Update OBS Deps
- FFMPEG 6 compatible code: Remove non-existant AVBufferSinkParams. It was already deprecated and unused.